### PR TITLE
make df work on older Linux distros

### DIFF
--- a/recipe/repo.py
+++ b/recipe/repo.py
@@ -35,10 +35,9 @@ def atouch(f):
     os.utime(f, None)
 
 def df(f):
-    "Returns number of free blocks"
-    x=subprocess.check_output(["df", "--output=avail", str(f)]).split()
-    # Output on second line
-    return int(x[1])
+    "Returns number of free bytes"
+    f = os.statvfs(str(f))
+    return f.f_bavail * f.f_bsize
 
 def evict_m(d):
     """If not enough free space, evict"""


### PR DESCRIPTION
CentOS 6 has a df(1) that doesn't support --output. Implement the df
function using the os.statvfs module instead. Also return the number
of free bytes as this is what the callers seem to expect.